### PR TITLE
Specify the version of this nsrr package

### DIFF
--- a/R/nsrr_download.R
+++ b/R/nsrr_download.R
@@ -33,7 +33,7 @@ nsrr_download_url = function(
     "a",
     token,
     "m",
-    paste0("nsrr-gem-v", gsub("[.]", "-", ver)),
+    paste0("nsrr-r-v0-1-0"),
     path)
   return(fname)
 }


### PR DESCRIPTION
The "m" or medium defines what program is accessing the file, in this case, the NSRR R downloader (or nsrr-r-v0-1-0) and it's used to help the NSRR determine traffic from different sources (mediums). Example sources are "browser" (downloading in your browser), "nsrr-gem-v4-0-0" (The nsrr/nsrr-gem's current version).